### PR TITLE
fix(oauth): configure browser with what oauth server thinks is its public url

### DIFF
--- a/_scripts/profile.js
+++ b/_scripts/profile.js
@@ -14,7 +14,7 @@ var CONFIGS = {
     content: 'http://127.0.0.1:3030/',
     token: 'http://localhost:5000/token/1.0/sync/1.5',
     loop: 'http://localhost:10222',
-    oauth: 'http://localhost:9010/v1',
+    oauth: 'http://127.0.0.1:9010/v1',
     profile: 'http://localhost:1111/v1'
   },
   'latest': {


### PR DESCRIPTION
The oauth-server thinks its publicUrl is `127.0.0.1`, and checks for this in browserid assertions.  The config value in the browser must match, or it get "invalid audience" errors when generating oauth tokens.