### PR TITLE
feat(basket): use stand-alone fxa-basket-proxy repo.

### DIFF
--- a/_scripts/install_all.sh
+++ b/_scripts/install_all.sh
@@ -14,6 +14,8 @@ git clone https://github.com/mozilla/fxa-oauth-console.git &
 
 git clone https://github.com/mozilla/fxa-profile-server.git &
 
+git clone https://github.com/mozilla/fxa-basket-proxy.git &
+
 git clone https://github.com/mozilla/123done.git -b oauth &
 
 git clone https://github.com/mozilla-services/loop-server.git &
@@ -36,6 +38,8 @@ cd fxa-oauth-server; npm i; cd ..
 cd fxa-oauth-console; npm i; cd ..
 
 cd fxa-profile-server; npm i; mkdir -p var/public/; cd ..
+
+cd fxa-basket-proxy; npm i; cd ..
 
 cd 123done; npm i; CONFIG_123DONE=./config-local.json node ./scripts/gen_keys.js; cd ..
 

--- a/_scripts/update_all.sh
+++ b/_scripts/update_all.sh
@@ -11,6 +11,8 @@
 
 (cd fxa-profile-server && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-profile-server update failed"
 
+(cd fxa-basket-proxy && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-basket-proxy update failed"
+
 (cd 123done && git checkout oauth && git pull origin oauth && npm i && cd ..) || echo "123done update failed"
 (cd loop-server && git checkout master && git pull origin master && npm i && cd ..) || echo "Loop update failed"
 (cd syncserver && git checkout master && git pull origin master && make build && cd ..) || echo "syncserver update failed"

--- a/servers.json
+++ b/servers.json
@@ -38,15 +38,15 @@
       "max_restarts": "1"
     },
     {
-      "name": "content-server basket proxy PORT 1114",
-      "script": "server/bin/basket-proxy-server.js",
-      "cwd": "fxa-content-server",
+      "name": "fxa-basket-proxy PORT 1114",
+      "script": "./bin/basket-proxy-server.js",
+      "cwd": "fxa-basket-proxy",
       "max_restarts": "1"
     },
     {
-      "name": "content-server null basket server PORT 10140",
-      "script": "server/bin/null-basket-server.js",
-      "cwd": "fxa-content-server",
+      "name": "fxa-basket-proxy fake basket server PORT 10140",
+      "script": "./bin/fake-basket-server.js",
+      "cwd": "fxa-basket-proxy",
       "max_restarts": "1"
     },
     {


### PR DESCRIPTION
The fxa-basket-proxy repo change have landed, this change is now ready to go.  @vladikoff r?

Fixes #35.