### PR TITLE
feat(vagrant): add provision script and improve current vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules
 pm2
 dump.rdb
 *.log
+
+.vagrant
+local_config.yaml

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,27 +1,51 @@
 # -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
 
 VAGRANTFILE_API_VERSION = "2"
+localConfigPath = "local_config.yaml"
+
+if File.exists?localConfigPath then
+  settings = YAML::load(File.read(localConfigPath))
+else
+  settings = Hash.new
+end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "trusty64"
-  config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = "ubuntu/trusty64"
 
   config.ssh.forward_agent = true
   config.ssh.insert_key = false
 
-  config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "1536"]
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = settings["memory"] ||= "1536"
   end
 
   config.vm.define "dev", primary: true do |dev|
-    dev.vm.network :private_network, ip: "192.168.50.10"
+    dev.vm.network "private_network", ip: settings["ip"] ||= "192.168.50.10"
+    dev.vm.network "forwarded_port", guest: 1111, host: 1111
+    dev.vm.network "forwarded_port", guest: 1112, host: 1112
+    dev.vm.network "forwarded_port", guest: 1113, host: 1113
+    dev.vm.network "forwarded_port", guest: 1114, host: 1114
     dev.vm.network "forwarded_port", guest: 3030, host: 3030
+    dev.vm.network "forwarded_port", guest: 5000, host: 5000
+    dev.vm.network "forwarded_port", guest: 5050, host: 5050
+    dev.vm.network "forwarded_port", guest: 8080, host: 8080
     dev.vm.network "forwarded_port", guest: 9000, host: 9000
     dev.vm.network "forwarded_port", guest: 9010, host: 9010
+    dev.vm.network "forwarded_port", guest: 9011, host: 9011
+    dev.vm.network "forwarded_port", guest: 10137, host: 10137
+    dev.vm.network "forwarded_port", guest: 10139, host: 10139
+    dev.vm.network "forwarded_port", guest: 10140, host: 10140
   end
 
-  config.push.define "atlas" do |push|
-    push.app = "vladikoff/fxa-local-dev"
-    push.dir = "."
+  config.vm.provision "shell", privileged: false, path: "_scripts/vagrant_provision.sh", args: Vagrant::Util::Platform.windows?.to_s.upcase
+
+  if settings.has_key?("push.app") then
+    config.push.define "atlas" do |push|
+      push.app = settings["push.app"]
+      push.dir = settings["push.dir"] ||= "."
+    end
   end
 end

--- a/_scripts/vagrant_provision.sh
+++ b/_scripts/vagrant_provision.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+echo "### Adding Java and Node.js repositories ###"
+sudo add-apt-repository -y ppa:webupd8team/java
+curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+
+echo "### Installing dependencies ###"
+sudo apt-get install -y build-essential git-core libgmp3-dev graphicsmagick redis-server python-virtualenv python-dev
+
+echo "### Installing Node.js ###"
+sudo apt-get install -y nodejs
+
+echo "### Checking if npm is older than 2.4 ###"
+if [[ $(npm -v | awk '{print $1}') < 2.4 ]]; then
+  echo "Updating npm to 2.4"
+  sudo npm install -g npm@2.4
+fi
+
+echo "### Accepting Oracle licence and installing Java ###"
+echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
+echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
+sudo apt-get install -y oracle-java7-installer
+
+if [ "$1" != "TRUE" ]; then
+  echo "### Installing development environment ###"
+  cd /vagrant; npm install
+else
+  echo "### You need to manually install development environment ###"
+fi

--- a/local_config.yaml.example
+++ b/local_config.yaml.example
@@ -1,0 +1,7 @@
+---
+ip: "192.168.50.10"
+
+memory: 1536
+
+#push.app:
+#push.dir:

--- a/servers.json
+++ b/servers.json
@@ -25,14 +25,15 @@
       "script": "bin/key_server.js",
       "cwd": "fxa-auth-server",
       "env": {
-        "NODE_ENV": "dev"
+        "NODE_ENV": "dev",
+        "IP_ADDRESS": "0.0.0.0"
       },
       "max_restarts": "1",
       "min_uptime": "2m"
     },
     {
       "name": "content-server PORT 3030",
-      "script": "node_modules/.bin/grunt",
+      "script": "node_modules/grunt-cli/bin/grunt",
       "args": ["server"],
       "cwd": "fxa-content-server",
       "env": {
@@ -60,7 +61,8 @@
       "script": "bin/server.js",
       "cwd": "fxa-oauth-server",
       "env": {
-        "NODE_ENV": "dev"
+        "NODE_ENV": "dev",
+        "HOST" : "0.0.0.0"
       },
       "max_restarts": "1",
       "min_uptime": "2m"
@@ -70,7 +72,8 @@
       "script": "bin/internal.js",
       "cwd": "fxa-oauth-server",
       "env": {
-        "NODE_ENV": "dev"
+        "NODE_ENV": "dev",
+        "HOST_INTERNAL" : "0.0.0.0"
       },
       "max_restarts": "1",
       "min_uptime": "2m"
@@ -81,7 +84,8 @@
       "cwd": "fxa-profile-server",
       "max_restarts": "1",
       "env": {
-        "NODE_ENV": "dev"
+        "NODE_ENV": "dev",
+        "HOST": "0.0.0.0"
       },
       "min_uptime": "2m"
     },
@@ -101,7 +105,8 @@
       "cwd": "fxa-profile-server",
       "max_restarts": "1",
       "env": {
-        "NODE_ENV": "dev"
+        "NODE_ENV": "dev",
+        "WORKER_HOST": "0.0.0.0"
       },
       "min_uptime": "2m"
     },
@@ -132,7 +137,8 @@
       "script": "bin/server.js",
       "cwd": "fxa-oauth-console",
       "env": {
-        "NODE_ENV": "dev"
+        "NODE_ENV": "dev",
+        "HOST": "0.0.0.0"
       },
       "max_restarts": "1",
       "min_uptime": "2m"
@@ -142,10 +148,11 @@
       "script": "server.js",
       "cwd": "browserid-verifier",
       "env": {
-        "PORT": "5050"
+        "PORT": "5050",
+        "IP_ADDRESS": "0.0.0.0"
       },
       "max_restarts": "1",
-      "min_uptime": "2m" 
+      "min_uptime": "2m"
     },
     {
       "name": "sync server PORT 5000",


### PR DESCRIPTION
The following sections explains what changed and the reason. The Windows section explains the steps to get the machine working on windows and is here just for reference.

**Vagrantfile**
This file has been improved with the following changes:
1. Load configuration file (yaml) if exists.
2. Updated the format of box dependency declaration.
3. Memory and IP can be defined externally (in yaml file).
4. The atlas push must be configured in the external file.

**vagrant_provision.sh**
This file contains the steps required to build a working development environment.

**local_config.yaml.example**
This file should be duplicated and renamed to 'local_config.yaml' when overriding some configurations.

**servers.json**
Changed to not use the symlink when starting grunt (see windows host section).

**Windows Host**
Using Windows as host is not straight forward and requires some special steps. Why? Because VirtualBox does not support symlinks inside the shared folder. There is a way to get the symlinks working but it comes by default disabled because it can have an unpredictable behaviour.
There was an issue with paths because npm creates the nested tree of dependencies resulting in a path longer than 256 characters, but is already solved in Vagrant 1.8.0 with VirtualBox latest version of 4.3 and 5.

Steps to manually install
1. Install globally the following packages because the install needs to find their executables (does not find them because symlinks are not being created).
sudo npm install -g bower
sudo npm install -g node-pre-gyp
sudo npm install -g browserify
sudo npm install -g uglifyjs

2. Use the following command to set npm to ignore symlink creation (restart the ssh connection after).
echo "alias npm='npm --no-bin-links'" >> ~/.bash_aliases

3. Since linux bash does not nest the alias, we need to change the 'install_all.sh' to manually ignore symlink creation. Run the following script.
sed -i 's/npm i/npm i --no-bin-links/g' _scripts/install_all.sh

4. We need to tell virtualenv to not create symlinks. Put the following line after wait in 'install_all.sh' script.
sed -i '/$(VIRTUALENV)/ s/ / --always-copy /' syncserver/Makefile

5. Replace the symlink at the end of 'install_all.sh' script (this will create a wrapper script to simulate the symlink).
echo -e '#!/bin/bash\nexec ./node_modules/pm2/bin/pm2 "$@"' > pm2; chmod +x pm2

Now you can run 'npm install' as usual. After the install just revert the changes to the script.

Note: I do not recommend using Windows to develop anything related with the current trending web frameworks (even when using Vagrant), but if you really depend on Windows like me (for now), the above steps should help you getting the development machine working.
