### PR TITLE
fxa-oauth-console requires rebuild of web interface before server starts

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -134,7 +134,7 @@
     },
     {
       "name": "fxa-oauth-console PORT 10137",
-      "script": "bin/server.js",
+      "script": "scripts/run_dev.js",
       "cwd": "fxa-oauth-console",
       "env": {
         "NODE_ENV": "dev",


### PR DESCRIPTION
Hi @vladikoff!
I tried to setup fxa-oauth-console yesterday and I've noticed this error:
http://storage2.static.itmages.com/i/16/0706/h_1467844576_1587389_c7b03c0b11.png

After a small digging I noticed that scripts should rebuild the dashboard before start of final server. I believe that scripts/run_dev.js implements this behaviour.