### PR TITLE
Removed explicit sleep in favor of active waiting for the…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,7 @@ script:
   - if [ $TRAVIS_NODE_VERSION == "4" ]; then export CXX=g++-4.8; fi
   - npm config set spin false
   - npm install
-  - sleep 30
   - ./test/curl.sh
+
+after_failure:
+  - pm2 status


### PR DESCRIPTION
Hi @vladikoff!
I rewritten travis-ci tests in order to remove explicit waits. After  that, tests are passing without any problems on linux:
https://travis-ci.org/jotes/fxa-local-dev/builds/143208528

Could you review this patch?