### PR TITLE
fix(install): Generate VAPID keys during auth-server install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - npm --version
 
 script:
-  - if [ $TRAVIS_NODE_VERSION == "4" ]; then export CXX=g++-4.8; fi
+  - if [ $TRAVIS_NODE_VERSION == "4.5" ]; then export CXX=g++-4.8; fi
   - npm config set spin false
   - npm install
   - ./test/curl.sh

--- a/_scripts/install_all.sh
+++ b/_scripts/install_all.sh
@@ -35,7 +35,8 @@ wait
 
 cd fxa-content-server; npm i --production; npm i; cp server/config/local.json-dist server/config/local.json; cd ..
 
-cd fxa-auth-server; npm i; node ./scripts/gen_keys.js; cd ..
+cd fxa-auth-server; npm i; node ./scripts/gen_keys.js; node ./scripts/gen_vapid_keys.js ; cd ..
+
 # Install a custom http only verifier
 cd browserid-verifier; npm i; npm i vladikoff/browserid-local-verify#http; cd ..
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/1502; @shane-tomlinson r?