### PR TITLE
feat(config): Add force signin unblock email config.

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -26,7 +26,8 @@
       "cwd": "fxa-auth-server",
       "env": {
         "NODE_ENV": "dev",
-        "IP_ADDRESS": "0.0.0.0"
+        "IP_ADDRESS": "0.0.0.0",
+        "SIGNIN_UNBLOCK_FORCED_EMAILS": "^block.*@restmail\\.net$"
       },
       "max_restarts": "1",
       "min_uptime": "2m"


### PR DESCRIPTION
Force on *.mozilla.com, and block.*@restmail.net addresses

This enables all of the content server functional tests related to signin unblock to pass. Without it, the tests that test for signin unblock do not pass because no email addresses are forced.