### PR TITLE
fix(vagrant): update npm version from 2.4 to 2.x

### DIFF
--- a/_scripts/vagrant_provision.sh
+++ b/_scripts/vagrant_provision.sh
@@ -1,29 +1,38 @@
 #!/bin/bash -e
 
-echo "### Adding Java and Node.js repositories ###"
-sudo add-apt-repository -y ppa:webupd8team/java
-curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+echo "Adding Java and Node.js repositories"
+sudo add-apt-repository -y ppa:webupd8team/java &>> ~/provision.log
+curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash - &>> \
+    ~/provision.log
 
-echo "### Installing dependencies ###"
-sudo apt-get install -y build-essential git-core libgmp3-dev graphicsmagick redis-server python-virtualenv python-dev
+echo "Installing dependencies"
+sudo apt-get install -y build-essential git-core libgmp3-dev graphicsmagick \
+    redis-server python-virtualenv python-dev &>> ~/provision.log
 
-echo "### Installing Node.js ###"
-sudo apt-get install -y nodejs
+echo "Installing Node.js"
+sudo apt-get install -y nodejs &>> ~/provision.log
 
-echo "### Checking if npm is older than 2.4 ###"
-if [[ $(npm -v | awk '{print $1}') < 2.4 ]]; then
-  echo "Updating npm to 2.4"
-  sudo npm install -g npm@2.4
+echo "Checking npm version"
+CURRENT_VERSION=$(npm -v | awk '{print $1}')
+INSTALL_VERSION=$(npm view npm@2 version | tail -1 | cut -d "'" -f2 |
+    awk '{print $1}')
+if [[ $CURRENT_VERSION < $INSTALL_VERSION ]]; then
+  echo "Updating npm from $CURRENT_VERSION to $INSTALL_VERSION"
+  sudo npm install npm@$INSTALL_VERSION -g &>> ~/provision.log
+else
+  echo "Npm is already at the desired version ($INSTALL_VERSION)"
 fi
 
-echo "### Accepting Oracle licence and installing Java ###"
-echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
-echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
-sudo apt-get install -y oracle-java7-installer
+echo "Accepting Oracle licence and installing Java 8"
+echo debconf shared/accepted-oracle-license-v1-1 select true |
+    sudo debconf-set-selections &>> ~/provision.log
+echo debconf shared/accepted-oracle-license-v1-1 seen true |
+    sudo debconf-set-selections &>> ~/provision.log
+sudo apt-get install -y oracle-java8-installer &>> ~/provision.log
 
 if [ "$1" != "TRUE" ]; then
-  echo "### Installing development environment ###"
+  echo "Installing development environment"
   cd /vagrant; npm install
 else
-  echo "### You need to manually install development environment ###"
+  echo "You need to manually install development environment"
 fi


### PR DESCRIPTION
Update the npm version installed by vagrant provisioning to the latest version of 2.x.
All dependencies installation log goes to the file ~/provision.log.
Refactored and improved the provisioning messages.
Lines wrapped at 80.