### PR TITLE
fix(config): disable geo-lookup for auth server /sms/status

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -29,7 +29,8 @@
         "IP_ADDRESS": "0.0.0.0",
         "SIGNIN_UNBLOCK_FORCED_EMAILS": "^block.*@restmail\\.net$",
         "SIGNIN_CONFIRMATION_ENABLED": "true",
-        "SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX": "^sync.*@restmail\\.net$"
+        "SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX": "^sync.*@restmail\\.net$",
+        "SMS_STATUS_GEO_ENABLED": "false"
       },
       "max_restarts": "1",
       "min_uptime": "2m"


### PR DESCRIPTION
Related to mozilla/fxa-auth-server#1750.

@mozilla/fxa-devs r?