### PR TITLE
goaws : fake sqs/sns server

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ If you get an `error` status for any of the servers please verify that you insta
 [Redis](http://redis.io/),
 [libgmp](https://gmplib.org/),
 [graphicsmagick](http://www.graphicsmagick.org/),
-[memcached](https://memcached.org/).
+[memcached](https://memcached.org/),
+[docker](https://docs.docker.com/).
 
 **Note:** Node.js 8 is not currently supported. Please use Node.js 6+.
 
@@ -98,12 +99,17 @@ then:
 brew install gmp redis graphicsmagick memcached
 sudo easy_install pip && sudo pip install virtualenv
 ```
+[Install Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
 
 ##### Ubuntu:
 ```
-sudo apt-get install build-essential git-core libgmp3-dev graphicsmagick redis-server python-virtualenv python-dev memcached
+sudo apt-get install build-essential git-core libgmp3-dev graphicsmagick redis-server python-virtualenv
+python-dev memcached docker-ce
 ```
-
+#### Pull GoAws image for local SQS / SNS fake server
+```
+docker pull pafortin/goaws
+```
 #### Installing Node.js
 
 > NOTE: If you are experienced with Node.js: Use [nvm](https://github.com/creationix/nvm) to force node 6

--- a/_scripts/goaws.sh
+++ b/_scripts/goaws.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+container_id=$(docker ps -a | grep pafortin/goaws | cut -d' ' -f1)
+if [ -z "$container_id" ]; then
+  docker run -d --name goaws -p 4100:4100 pafortin/goaws
+else
+  is_up=$(docker ps -a | grep pafortin/goaws | grep Up | cut -d' ' -f1)
+  if [ -z "$is_up" ]; then
+    docker start $container_id
+  else
+    echo $container_id
+  fi
+fi

--- a/servers.json
+++ b/servers.json
@@ -167,6 +167,10 @@
       "script": "_scripts/memcached.js",
       "max_restarts": "1",
       "min_uptime": "2m"
+    },
+    {
+      "name": "goaws",
+      "script": "_scripts/goaws.sh",
     }
   ]
 }


### PR DESCRIPTION
@vladikoff have added script to start goaws as a docker container but i could not find a way out to stop it using ./pm2 stop , it needs to tun "docker stop container_id", do we need to make it a part of start script only.
I have imported postman collection for Amazon AWS from :
[https://www.getpostman.com/collections/091386eae8c70588348e](https://www.getpostman.com/collections/091386eae8c70588348e)
as recommended in [(https://github.com/p4tin/goaws)]((https://github.com/p4tin/goaws))

I need some more input to make the tests running in `npm run test-functional -- --grep="opt-in on signup" `

