### PR TITLE
fix(oauth): Fix the content server's OAuth functional tests.

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -65,7 +65,8 @@
       "cwd": "fxa-oauth-server",
       "env": {
         "NODE_ENV": "dev",
-        "HOST" : "0.0.0.0"
+        "HOST" : "0.0.0.0",
+        "FXA_OPENID_ISSUER": "http://127.0.0.1:3030"
       },
       "max_restarts": "1",
       "min_uptime": "2m"


### PR DESCRIPTION
The issuer when verifying tokens was `https://accounts.firefox.com`
which didn't match the local content server. This fixes that
by setting FXA_OPENID_ISSUER on the OAuth server to be
the local content server.

fixes mozilla/fxa-content-server#6362

@vladikoff - r?