### PR TITLE
fix(syncserver): Update syncserver script for latest docker image.

### DIFF
--- a/_scripts/syncserver.sh
+++ b/_scripts/syncserver.sh
@@ -16,6 +16,5 @@ docker run --net=host --rm --name syncserver \
   -e SYNCSERVER_SQLURI=sqlite:////tmp/syncserver.db \
   -e SYNCSERVER_BATCH_UPLOAD_ENABLED=true \
   -e SYNCSERVER_FORCE_WSGI_ENVIRON=false \
-  mozilla/syncserver:latest \
-  /usr/local/bin/gunicorn --bind 0.0.0.0:5000 \
-  syncserver.wsgi_app
+  -e PORT=5000 \
+  mozilla/syncserver:latest


### PR DESCRIPTION
After the migration to CircleCI 2, the syncserver docker image
now runs gunicorn by default, so we don't need to specify it
explicitly.

Fixes #117