### PR TITLE
fix(update): Still install if a lockfile has been updated.

### DIFF
--- a/_scripts/update_all.sh
+++ b/_scripts/update_all.sh
@@ -4,20 +4,20 @@
 
 git pull https://github.com/mozilla/fxa-local-dev.git master
 
-(cd fxa-content-server && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-content-server update failed"
-(cd fxa-auth-server && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-auth-server update failed"
+(cd fxa-content-server && git checkout -- . && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-content-server update failed"
+(cd fxa-auth-server && git checkout -- . && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-auth-server update failed"
 
-(cd fxa-auth-db-mysql && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-auth-db-mysql update failed"
+(cd fxa-auth-db-mysql && git checkout -- . && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-auth-db-mysql update failed"
 
-(cd fxa-email-service && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-email-service update failed"
+(cd fxa-email-service && git checkout -- . && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-email-service update failed"
 
-(cd browserid-verifier && git checkout master && git pull origin master && npm i && cd ..)|| echo "browserid update failed"
-(cd fxa-oauth-server && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-oauth-server update failed"
+(cd browserid-verifier && git checkout -- . && git checkout master && git pull origin master && npm i && cd ..)|| echo "browserid update failed"
+(cd fxa-oauth-server && git checkout -- . && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-oauth-server update failed"
 
-(cd fxa-profile-server && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-profile-server update failed"
+(cd fxa-profile-server && git checkout -- . && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-profile-server update failed"
 
-(cd fxa-basket-proxy && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-basket-proxy update failed"
+(cd fxa-basket-proxy && git checkout -- . && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-basket-proxy update failed"
 
-(cd 123done && git checkout oauth && git pull origin oauth && npm i && cd ..) || echo "123done update failed"
+(cd 123done && git checkout -- . && git checkout oauth && git pull origin oauth && npm i && cd ..) || echo "123done update failed"
 docker pull mozilla/syncserver || echo "syncserver update failed"
 


### PR DESCRIPTION
I kept having problems updating because npm-shrinkwrap.json
was updated after the last install.

This does a `git checkout -- .` in each directory to ensure
a clean install.

@vladikoff - r?