### PR TITLE
Add pushbox server

### DIFF
--- a/_scripts/check_mysql.sh
+++ b/_scripts/check_mysql.sh
@@ -1,9 +1,10 @@
 #!/bin/bash -ex
 
 function check_mysql() {
+  PORT=${1:-3306}
   RETRY=12
   for i in $(eval echo "{1..$RETRY}"); do
-    if echo PING | nc localhost 3306 | grep -q 'mysql'; then
+    if echo PING | nc localhost $PORT | grep -q 'mysql'; then
       return 0
     else
       if [ $i -lt $RETRY ]; then

--- a/_scripts/create_mysql.js
+++ b/_scripts/create_mysql.js
@@ -52,6 +52,15 @@ servers.apps.forEach((app) => {
     app.script = '_scripts/profile_mysql.sh';
   }
 
+  if(app.script === '_scripts/pushbox_db.sh') {
+    // Because we piggyback on the existing MySQL db.
+    return;
+  }
+
+  if(app.script === '_scripts/pushbox.sh') {
+    app.args = '3306 root@mydb:3306';
+  }
+
   newServers.push(app);
 });
 

--- a/_scripts/install_all.sh
+++ b/_scripts/install_all.sh
@@ -53,14 +53,16 @@ cd fxa-basket-proxy; npm i; cd ..
 
 cd 123done; npm i; cd ..
 
+docker network create fxa-net || true
+
 docker pull memcached
 
 docker pull mozilla/syncserver
 
+docker pull mozilla/pushbox
+
 docker pull pafortin/goaws
 
 docker pull redis
-
-docker pull mysql/mysql-server:5.6
 
 ln -sf node_modules/.bin/pm2 pm2

--- a/_scripts/pushbox.sh
+++ b/_scripts/pushbox.sh
@@ -1,0 +1,36 @@
+#!/bin/sh -ex
+sleep 3 # Give 3 secs to the mysql server to start
+. _scripts/check_mysql.sh
+
+# This docker image doesn't react to SIGINTs (Ctrl+C) which is used by
+# pm2 to kill processes.
+# We go around this by defining a SIGINT handler, running docker in the
+# background (but still logging on the screen), and running a read to keep
+# the script running.
+
+function on_singint() {
+  echo "Pushbox shutting down."
+  docker stop pushbox
+  exit 0
+}
+
+MYSQL_HOST_PORT=${1:-4306}
+MYSQL_URI=${2:-test:test@pushbox_db:3306} #3306 because -p is only for the host.
+
+check_mysql $MYSQL_HOST_PORT
+mysqlStarted=$?
+
+if [ "$mysqlStarted" ]; then
+
+  trap on_singint INT
+
+  docker run --rm --name pushbox \
+    --network fxa-net \
+    -p 8002:8002 \
+    -e ROCKET_PORT=8002 \
+    -e ROCKET_SERVER_TOKEN=Correct_Horse_Battery_Staple_1 \
+    -e ROCKET_DATABASE_URL=mysql://$MYSQL_URI/pushbox \
+    pushbox &
+
+  while :; do read; done
+fi

--- a/_scripts/pushbox_db.sh
+++ b/_scripts/pushbox_db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/sh -ex
 
 # This docker image doesn't react to SIGINTs (Ctrl+C) which is used by
 # pm2 to kill processes.
@@ -7,20 +7,20 @@
 # the script running.
 
 function on_singint() {
-  echo "MySQL shutting down."
-  docker stop mydb
+  echo "Pushbox DB shutting down."
+  docker stop pushbox_db
   exit 0
 }
 
 trap on_singint INT
 
-# Create pushbox db on start (because pushbox doesn't create it)
-docker run --rm --name=mydb \
+docker run --rm --name pushbox_db \
   --network fxa-net \
-  -e MYSQL_ALLOW_EMPTY_PASSWORD=true \
-  -e MYSQL_ROOT_HOST=% \
+  -p 4306:3306 \
+  -e MYSQL_ROOT_PASSWORD=random \
   -e MYSQL_DATABASE=pushbox \
-  -p 3306:3306 \
+  -e MYSQL_USER=test \
+  -e MYSQL_PASSWORD=test \
   mysql/mysql-server:5.6 &
 
 while :; do read; done

--- a/_scripts/syncserver.sh
+++ b/_scripts/syncserver.sh
@@ -10,7 +10,7 @@ fi
 
 docker run --rm --name syncserver \
   -p 5000:5000 \
-  -e SYNCSERVER_PUBLIC_URL=http://localhost:5000 \
+  -e SYNCSERVER_PUBLIC_URL=http://127.0.0.1:5000 \
   -e SYNCSERVER_BROWSERID_VERIFIER=http://$HOST_ADDR:5050 \
   -e SYNCSERVER_SECRET=5up3rS3kr1t \
   -e SYNCSERVER_SQLURI=sqlite:////tmp/syncserver.db \

--- a/_scripts/update_all.sh
+++ b/_scripts/update_all.sh
@@ -18,6 +18,9 @@ git pull https://github.com/mozilla/fxa-local-dev.git master
 
 (cd fxa-basket-proxy && git checkout -- . && git checkout master && git pull origin master && npm i && cd ..) || echo "fxa-basket-proxy update failed"
 
+# Migration
+docker network create fxa-net || true # Don't error out in case the network already exists
+
 (cd 123done && git checkout -- . && git checkout oauth && git pull origin oauth && npm i && cd ..) || echo "123done update failed"
 docker pull mozilla/syncserver || echo "syncserver update failed"
 

--- a/mysql_servers.json
+++ b/mysql_servers.json
@@ -151,7 +151,8 @@
       "cwd": "browserid-verifier",
       "env": {
         "PORT": "5050",
-        "IP_ADDRESS": "0.0.0.0"
+        "IP_ADDRESS": "0.0.0.0",
+        "FORCE_INSECURE_LOOKUP_OVER_HTTP": "true"
       },
       "max_restarts": "1",
       "min_uptime": "2m"
@@ -184,6 +185,23 @@
       "max_restarts": "1",
       "min_uptime": "2m",
       "autorestart": false
+    },
+    {
+      "name": "email-service PORT 8001",
+      "script": "scripts/run_send.sh",
+      "cwd": "fxa-email-service",
+      "env": {
+        "NODE_ENV": "dev"
+      },
+      "max_restarts": "1",
+      "min_uptime": "2m"
+    },
+    {
+      "name": "pushbox PORT 8002",
+      "script": "_scripts/pushbox.sh",
+      "max_restarts": "1",
+      "min_uptime": "2m",
+      "args": "3306 root@mydb:3306"
     }
   ]
 }

--- a/servers.json
+++ b/servers.json
@@ -174,6 +174,18 @@
       },
       "max_restarts": "1",
       "min_uptime": "2m"
+    },
+    {
+      "name": "pushbox db PORT 4306",
+      "script": "_scripts/pushbox_db.sh",
+      "max_restarts": "1",
+      "min_uptime": "2m"
+    },
+    {
+      "name": "pushbox PORT 8002",
+      "script": "_scripts/pushbox.sh",
+      "max_restarts": "1",
+      "min_uptime": "2m"
     }
   ]
 }


### PR DESCRIPTION
This PR allows running a [pushbox](https://github.com/mozilla-services/pushbox) server alongside all the other FxA services.
In the `mysql_servers.json` pm2 configuration, we use the already existing `mydb` mysql container to store our data, otherwise we spawn a `pushbox_db` container (pushbox doesn't have a memory store).

I've also used my "sigint trap trick" to make `mydb` stop after the user runs `pm2 kill`.