### PR TITLE
fix(syncserver): run the syncserver in container network

### DIFF
--- a/_scripts/syncserver.sh
+++ b/_scripts/syncserver.sh
@@ -8,7 +8,7 @@ else
   HOST_ADDR='127.0.0.1'
 fi
 
-docker run --net=host --rm --name syncserver \
+docker run --rm --name syncserver \
   -p 5000:5000 \
   -e SYNCSERVER_PUBLIC_URL=http://localhost:5000 \
   -e SYNCSERVER_BROWSERID_VERIFIER=http://$HOST_ADDR:5050 \


### PR DESCRIPTION
https://github.com/mozilla/fxa-local-dev/pull/114 didn't fix my problem (not able to sync after a fresh clone of `fxa-local-dev`).
Running without `--net=host` seems sensible to me since we already pass `host.docker.internal` to the docker image.