### PR TITLE
refactor(scripts): Refactor update_all for clarity and handle npm lock files

### DIFF
--- a/_scripts/helpers.sh
+++ b/_scripts/helpers.sh
@@ -1,0 +1,33 @@
+# Helper methods for working with git, npm, docker, and rust projects.
+
+function update_git_branch() {
+  git checkout $1 && git pull origin $1
+}
+
+function select_git_branch() {
+  branch=$1
+  if [ -z $branch ]; then
+    branch="master"
+  fi
+}
+
+function revert_npm_lock_files() {
+  git checkout -- npm-shrinkwrap.json 2> /dev/null || true
+  git checkout -- package-lock.json 2> /dev/null || true
+}
+
+function update_node_repo() {
+  echo "Updating $1 with branch $branch"
+  select_git_branch $2
+  (cd $1 && revert_npm_lock_files && update_git_branch $branch && npm ci && cd .. && echo "$1 updated") || echo "$1 update failed"
+}
+
+function update_rust_repo() {
+  select_git_branch $2
+  echo "Updating $1 with branch $branch to create $3"
+  (cd $1 && update_git_branch $branch && cargo build --bin $3 && cd .. && echo "$1 updated") || echo "$1 update failed"
+}
+
+function update_docker_image() {
+  docker pull $1 || echo "$1 update failed"
+}

--- a/_scripts/install_all.sh
+++ b/_scripts/install_all.sh
@@ -44,8 +44,6 @@ cd fxa-email-service; cargo build --bin fxa_email_send; cd ..
 
 cd browserid-verifier; npm i; cd ..
 
-cd fxa-auth-server/fxa-oauth-server; npm i; cd ../..
-
 cd fxa-profile-server; npm i; mkdir -p var/public/; cd ..
 
 cd fxa-basket-proxy; npm i; cd ..

--- a/_scripts/update_all.sh
+++ b/_scripts/update_all.sh
@@ -1,28 +1,21 @@
 #!/bin/sh
 
-# Update all projects
+source $PWD/_scripts/helpers.sh
 
 git pull https://github.com/mozilla/fxa-local-dev.git master
 
-(cd fxa-content-server && git checkout master && git pull origin master && npm ci && cd ..) || echo "fxa-content-server update failed"
-(cd fxa-auth-server && git checkout master && git pull origin master && npm ci && cd ..) || echo "fxa-auth-server update failed"
+update_node_repo 123done oauth
+update_node_repo browserid-verifier
+update_node_repo fxa-auth-db-mysql
+update_node_repo fxa-auth-server
+update_node_repo fxa-basket-proxy
+update_node_repo fxa-content-server
+update_node_repo fxa-profile-server
 
-(cd fxa-auth-db-mysql && git checkout master && git pull origin master && npm ci && cd ..) || echo "fxa-auth-db-mysql update failed"
-
-(cd fxa-email-service && git checkout master && git pull origin master && npm ci && cd ..) || echo "fxa-email-service update failed"
-
-(cd browserid-verifier && git checkout master && git pull origin master && npm ci && cd ..)|| echo "browserid update failed"
-(cd fxa-oauth-server && git checkout master && git pull origin master && npm ci && cd ..) || echo "fxa-oauth-server update failed"
-
-(cd fxa-profile-server && git checkout master && git pull origin master && npm ci && cd ..) || echo "fxa-profile-server update failed"
-
-(cd fxa-basket-proxy && git checkout master && git pull origin master && npm ci && cd ..) || echo "fxa-basket-proxy update failed"
+update_rust_repo fxa-email-service master fxa_email_send
 
 # Migration
-docker network create fxa-net || true # Don't error out in case the network already exists
+docker network create fxa-net 2> /dev/null || true # Don't error out in case the network already exists
 
-(cd 123done && git checkout -- . && git checkout oauth && git pull origin oauth && npm ci && cd ..) || echo "123done update failed"
-
-docker pull mozilla/syncserver || echo "syncserver update failed"
-
-docker pull mozilla/channelserver || echo "channelserver update failed"
+update_docker_image mozilla/syncserver
+update_docker_image mozilla/channelserver


### PR DESCRIPTION
Instead of doing one giant inline string, copied over and over, extract
that functionality into methods. Create methods for node, rust, and docker
repos.

fixes #145

@vladikoff - r?