### PR TITLE
fix(install): generate oauth server keys

### DIFF
--- a/_scripts/install_all.sh
+++ b/_scripts/install_all.sh
@@ -34,7 +34,7 @@ wait
 
 cd fxa-content-server; npm i --production; npm i; cp server/config/local.json-dist server/config/local.json; cd ..
 
-cd fxa-auth-server; npm i; node ./scripts/gen_keys.js; node ./scripts/gen_vapid_keys.js ; cd ..
+cd fxa-auth-server; npm i; node ./scripts/gen_keys.js; node ./scripts/gen_vapid_keys.js; node ./fxa-oauth-server/scripts/gen_keys; cd ..
 
 cd fxa-auth-db-mysql; npm i; cd ..
 


### PR DESCRIPTION
The OAuth server was not working after cloning `fxa-local-dev` on my new computer.
We used to call `node scripts/gen_keys` in the oauth server's package.json `postinstall` step, which doesn't exist anymore.